### PR TITLE
log scanix output to a file

### DIFF
--- a/bin/kwalarm
+++ b/bin/kwalarm
@@ -2,6 +2,7 @@
 
 source ~/scanix/lib/log4bash
 
+log="scanix.log"
 HELP=false
 VERB=false
 
@@ -76,9 +77,13 @@ else
             if [[ -n $EXPRESSION ]]; then
                 if [[ -n $NAME ]]; then line=$(printf "\t[%s] - %s" $NAME $line); fi
 		if [[ -n $EXCLUDES ]]; then 
-                    echo $line | grep -i -v -E "($EXCLUDES)" | grep --silent -i -E "($EXPRESSION)" && log_error "$line\n" || if $VERB; then log "$line"; fi
+		    echo $line | grep -i -v -E "($EXCLUDES)" | grep --silent -i -E "($EXPRESSION)" && \
+                        ( flock 200; log_error "$line\n" | tee -a "$log" ) 200>.scanix.lock \
+                    || if $VERB; then log "$line"; fi
                 else
-                    echo $line | grep --silent -i -E "($EXPRESSION)" && log_error "$line\n" || if $VERB; then log "$line"; fi
+		    echo $line | grep --silent -i -E "($EXPRESSION)" && \
+                        ( flock 200; log_error "$line\n" | tee -a "$log" ) 200>.scanix.lock \
+                    || if $VERB; then log "$line"; fi
                 fi
             fi
         done

--- a/bin/rtail
+++ b/bin/rtail
@@ -47,7 +47,7 @@ if $HELP; then
     echo -e "  Usage: rtail -f file -u user@host -p password"
     echo ""
 else
-    sshpass -p "$PASS" ssh -oStrictHostKeyChecking=no -C "$USERHOST" "tail -F $FILE"
+    sshpass -p "$PASS" ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -C "$USERHOST" "tail -F $FILE"
 fi
 
 


### PR DESCRIPTION
Scanix will now log to a file as well as output to the screen. The file logging is made thread/process safe through the utilization of 'flock'.
